### PR TITLE
Force Hide Blizzard Timers & show OmniCC

### DIFF
--- a/OmniCC/core/cooldown.lua
+++ b/OmniCC/core/cooldown.lua
@@ -140,7 +140,8 @@ function Cooldown:CanShowText()
     end
 
     if self.GetHideCountdownNumbers and not self:GetHideCountdownNumbers() then
-        return false
+        self:SetHideCountdownNumbers(true)
+        return true
     end
 
     local elapsed = GetTime() - start


### PR DESCRIPTION
I appreciate your quick fix to get the double text fixed, but I have made a tweak to basically inverse.

The only issue I am encountering now is that OmniCD is returning `nil` for their respective frames when applying timers. From my testing, this change seems to work everywhere else (Cooldown Manager included).